### PR TITLE
Remove the requirement for a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,17 @@ cmake_minimum_required( VERSION 3.2 )
 cmake_policy( SET CMP0048 NEW )
 
 #------------------------------------------------------------------------------
+#   Define the project
+#------------------------------------------------------------------------------
+
+set( EXTPKG_NAME  "decNumber"                                 )
+set( EXTPKG_VERS  "3.68.0"                                    )
+set( EXTPKG_DESC  "ANSI C General Decimal Arithmetic Library" )
+
+project( ${EXTPKG_NAME} VERSION ${EXTPKG_VERS} LANGUAGES C )
+set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE )
+
+#------------------------------------------------------------------------------
 #   Load some handy CMake modules
 #------------------------------------------------------------------------------
 
@@ -27,13 +38,6 @@ endif()
 
 include( ParseBinaryDir )
 ParseBinaryDir()
-
-
-#------------------------------------------------------------------------------
-#   Define the project
-#------------------------------------------------------------------------------
-
-include( project.txt )
 
 
 #------------------------------------------------------------------------------

--- a/cmake/modules/ParseBinaryDir.cmake
+++ b/cmake/modules/ParseBinaryDir.cmake
@@ -40,12 +40,6 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
     endif()
 
     #--------------------------------------------------------------------------
-    #   Enable C/C++ language
-    #--------------------------------------------------------------------------
-    
-    enable_language( C CXX )
-
-    #--------------------------------------------------------------------------
     #   Check if this is a BIG ENDIAN or LITTLE ENDIAN build system.
     #   Some packages needs to know this.
     #--------------------------------------------------------------------------

--- a/decNumber_VS2008.vcproj
+++ b/decNumber_VS2008.vcproj
@@ -356,10 +356,6 @@
 							>
 						</File>
 						<File
-							RelativePath="project.txt"
-							>
-						</File>
-						<File
 							RelativePath="sources.txt"
 							>
 						</File>

--- a/decNumber_VS2015.vcxproj
+++ b/decNumber_VS2015.vcxproj
@@ -209,7 +209,6 @@
     <Text Include="extra.txt" />
     <Text Include="headers.txt" />
     <Text Include="includes.txt" />
-    <Text Include="project.txt" />
     <Text Include="decnumber.readme.txt" />
     <Text Include="sources.txt" />
     <Text Include="targetver.txt" />

--- a/decNumber_VS2015.vcxproj.filters
+++ b/decNumber_VS2015.vcxproj.filters
@@ -264,9 +264,6 @@
     <Text Include="includes.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>
-    <Text Include="project.txt">
-      <Filter>Other Files\build\cmake\includes</Filter>
-    </Text>
     <Text Include="sources.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>

--- a/decNumber_VS2017.vcxproj
+++ b/decNumber_VS2017.vcxproj
@@ -209,7 +209,6 @@
     <Text Include="extra.txt" />
     <Text Include="headers.txt" />
     <Text Include="includes.txt" />
-    <Text Include="project.txt" />
     <Text Include="decnumber.readme.txt" />
     <Text Include="sources.txt" />
     <Text Include="targetver.txt" />

--- a/decNumber_VS2017.vcxproj.filters
+++ b/decNumber_VS2017.vcxproj.filters
@@ -264,9 +264,6 @@
     <Text Include="includes.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>
-    <Text Include="project.txt">
-      <Filter>Other Files\build\cmake\includes</Filter>
-    </Text>
     <Text Include="sources.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>

--- a/decNumber_VS2019.vcxproj
+++ b/decNumber_VS2019.vcxproj
@@ -209,7 +209,6 @@
     <Text Include="extra.txt" />
     <Text Include="headers.txt" />
     <Text Include="includes.txt" />
-    <Text Include="project.txt" />
     <Text Include="decnumber.readme.txt" />
     <Text Include="sources.txt" />
     <Text Include="targetver.txt" />

--- a/decNumber_VS2019.vcxproj.filters
+++ b/decNumber_VS2019.vcxproj.filters
@@ -264,9 +264,6 @@
     <Text Include="includes.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>
-    <Text Include="project.txt">
-      <Filter>Other Files\build\cmake\includes</Filter>
-    </Text>
     <Text Include="sources.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>

--- a/project.txt
+++ b/project.txt
@@ -2,11 +2,26 @@
 #   Define the project
 #------------------------------------------------------------------------------
 
-set( EXTPKG_NAME  "decNumber"                                 )
-set( EXTPKG_VERS  "3.68.0"                                    )
-set( EXTPKG_DESC  "ANSI C General Decimal Arithmetic Library" )
+# This file is no longer used!
 
-project( ${EXTPKG_NAME} VERSION ${EXTPKG_VERS} )
-set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE )
+# From: https://cmake.org/cmake/help/v3.2/command/project.html
+#
+# The top-level CMakeLists.txt file for a project must contain a literal,
+# direct call to the project() command; loading one through the include()
+# command is not sufficient. If no such call exists, CMake will issue a
+# warning and pretend there is a project(Project) at the top to enable the
+# default languages (C and CXX).
+#
+# Note Call the project() command near the top of the top-level CMakeLists.txt,
+# but after calling cmake_minimum_required(). It is important to establish
+# version and policy settings before invoking other commands whose behavior
+# they may affect. See also policy CMP0000.
+
+# set( EXTPKG_NAME  "decNumber"                                 )
+# set( EXTPKG_VERS  "3.68.0"                                    )
+# set( EXTPKG_DESC  "ANSI C General Decimal Arithmetic Library" )
+#
+# project( ${EXTPKG_NAME} VERSION ${EXTPKG_VERS} )
+# set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE )
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This change removes the requirement for a C++ compiler to be present for CMAKE.  This is sometimes the situation on certain Linux distributions and removes a stumbling block for novice builders.

**`CMakeLists.txt:`**

From: https://cmake.org/cmake/help/latest/command/project.html

> The top-level `CMakeLists.txt` file for a project must contain a literal, direct call to the `project()` command; loading one through the `include()` command is not sufficient. If no such call exists, CMake will issue a warning and pretend there is a `project(Project)` at the top to enable the default languages (`C` and `CXX`).
> 
> **Note:** Call the `project()` command near the top of the top-level `CMakeLists.txt`, but _after_ calling `cmake_minimum_required()`. It is important to establish version and policy settings before invoking other commands whose behavior they may affect. See also policy `CMP0000`.

**`ParseBinaryDir.cmake:`**

Move requirement for languages to `CMakeLists.txt`'s `project()` statement. Remove requirement for C++.